### PR TITLE
Provide missing code coverage in tests in package-manager

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -341,7 +341,8 @@
   "node-report": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": ["rnchamberlain", "richardlau"]
+    "maintainers": ["richardlau"],
+    "skip:": [">=15"]
   },
   "node-sass": {
     "prefix": "v",

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -249,6 +249,21 @@ test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append', (t) =
   });
 });
 
+test('citgm-all: install with yarn', (t) => {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup.json',
+    '-y'
+  ]);
+  proc.on('error', (err) => {
+    t.error(err);
+  });
+  proc.on('close', (code) => {
+    t.equals(code, 0, 'citgm-all should only run omg-i-pass');
+  });
+});
+
 test('bin: sigterm', (t) => {
   t.plan(1);
 


### PR DESCRIPTION
    Previously, the functions pkgInstall and pkgTest are missing
    code coverage for the lines involving yarn. The test added
    now checks these lines by passing in the -y argument when
    calling spawn. This does not test when the package doesn't include
    the tests, forcing citgm to grab the tarball from github.
    Writing such a test would involve setting the property
    useYarn.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
